### PR TITLE
Fix toid and fromid

### DIFF
--- a/admin/modules/tools/pmlog.php
+++ b/admin/modules/tools/pmlog.php
@@ -449,13 +449,13 @@ if(!$mybb->input['action'])
 		$additional_criteria[] = "subject=".urlencode($mybb->input['subject']);
 	}
 
-	if(!empty($mybb->input['fromuid']))
+	if(!empty($mybb->input['fromid']))
 	{
 		$additional_sql_criteria .= " AND p.fromid='{$fromid}'";
 		$additional_criteria[] = "fromid={$fromid}";
 	}
 
-	if(!empty($mybb->input['touid']))
+	if(!empty($mybb->input['toid']))
 	{
 		$additional_sql_criteria .= " AND p.toid='{$toid}'";
 		$additional_criteria[] = "toid={$toid}";


### PR DESCRIPTION
You changed the input values to fromuid and touid but didn't reflect this on the rest of the code, so the hyperlink in the admincp module still goes to fromid= instead of fromuid=.
Furthermore even if I manually rewrite it to fromuid= the PHP code is still setting $fromid value via fromid= so it still won't work.